### PR TITLE
use numpy.NaN for missing values in SimpleImputer

### DIFF
--- a/2_Data_Preprocessing/python/missing_data.py
+++ b/2_Data_Preprocessing/python/missing_data.py
@@ -1,17 +1,17 @@
-# Data Preprocessing
+""" Data Preprocessing
+"""
 
 # Importing the libraries
 import numpy as np
-import matplotlib.pyplot as plt
 import pandas as pd
+from sklearn.impute import SimpleImputer
 
 # Importing the dataset
-dataset = pd.read_csv('Data.csv')
+dataset = pd.read_csv('../Data.csv')
 X = dataset.iloc[:, :-1].values
 y = dataset.iloc[:, 3].values
 
 # Taking care of missing data
-from sklearn.impute import SimpleImputer
-imputer = SimpleImputer(missing_values = 'NaN', strategy = 'mean')
+imputer = SimpleImputer(missing_values=np.NaN, strategy='mean')
 imputer = imputer.fit(X[:, 1:3])
 X[:, 1:3] = imputer.transform(X[:, 1:3])


### PR DESCRIPTION
- Replaced `'NaN'` with `numpy.NaN` for the `missing_values` parameter when initializing SimpleImputer
- Fixes issue #51 